### PR TITLE
Add explicit visionOS support to DataCompression

### DIFF
--- a/DataCompression.podspec
+++ b/DataCompression.podspec
@@ -9,10 +9,11 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5'
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.11'
-  s.tvos.deployment_target = '9.0'
-  s.watchos.deployment_target = '2.0'
+  s.ios.deployment_target = '12.0'
+  s.osx.deployment_target = '10.13'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '4.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source_files = 'Sources/DataCompression/*.swift'
   s.requires_arc = true

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.9
 
 import PackageDescription
 
 let package = Package(
     name: "DataCompression",
-    platforms: [.macOS(.v10_11), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)],
+    platforms: [.macOS(.v10_13), .iOS(.v12), .tvOS(.v12), .watchOS(.v4), .visionOS(.v1)],
     products: [
         .library(
             name: "DataCompression",


### PR DESCRIPTION
# Overview

This PR adds explicit support for visionOS to both the CocoaPods `podspec` and the SPM `Package.swift` manifest.

# Description

While building an SDK that depends on DataCompression (specifically, [OpenTelemetry-Swift](https://github.com/open-telemetry/opentelemetry-swift)), I noticed that SPM was able to compile the package successfully for `visionOS` (even though `DataCompression` does not currently declare `visionOS` support explicitly).

I really don't know how's that possible, probably because:
- SPM does not enforce strict platform declarations for `visionOS` as long as no platform-specific APIs or `#if os(...)` conditions prevent compatibility.
or
- Xcode 16 can implicitly attempt to build for visionOS if no incompatibilities are found.

However, CocoaPods does validate platform declarations during `pod lib lint`, and the lack of explicit support causes validation to fail.

# Changes
- Added visionOS support to the `.podspec` (`s.visionos.deployment_target = '1.0'`).
- Upgraded `swift-tools-version` to `5.9` in `Package.swift` to explicitly support `visionOS` as a platform.
- Bumped the minimum deployment targets across all platforms (iOS, macOS, tvOS, watchOS) in both the `.podspec` and the `Package.swift` to align them and suppress Xcode warnings about deprecated versions.

> [!NOTE]  
> If you’d prefer **not to raise the minimum deployment targets across all platforms**, I’m happy to modify the PR to only add visionOS support in the `.podspec`, leaving the rest platforms (both in the `.podpsec` and `Package.swift`) untouched.