### PR TITLE
Added workflow to do a CocoaPods release

### DIFF
--- a/.github/workflows/push-podspec.yml
+++ b/.github/workflows/push-podspec.yml
@@ -1,0 +1,41 @@
+name: Push Podspec to CocoaPods
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Run in dry mode (only lint, no push)"
+        required: false
+        default: "false"
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  push:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set dryRun from workflow_dispatch or default to false
+        id: set_dry_run
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "dry_run=${{ github.event.inputs.dryRun }}" >> $GITHUB_OUTPUT
+          else
+            echo "dry_run=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Lint podspec (dry run)
+        if: ${{ steps.set_dry_run.outputs.dry_run == 'true' }}
+        run: |
+          pod lib lint DataCompression.podspec --allow-warnings --verbose
+
+      - name: Push to CocoaPods
+        if: ${{ steps.set_dry_run.outputs.dry_run == 'false' }}
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          pod trunk push DataCompression.podspec --allow-warnings --verbose


### PR DESCRIPTION
# Overview

This PR is related to the discussion in [this other PR](https://github.com/mw99/DataCompression/pull/37). It introduces a GitHub Actions workflow that enables pushing the `DataCompression.podspec` to CocoaPods.

# Details

The workflow will run in two scenarios:
- Whenever a new tag following semver (excluding pre-releases) is pushed (e.g., `x.y.z`)
- Manually via the Actions tab in the GitHub UI

It uses the `macos-latest` runner (as of now, [this corresponds to macOS 14](https://github.com/actions/runner-images)).

The workflow exposes a `dryRun` mode. When enabled, it will lint the podspec using `pod lib lint` instead of pushing it to trunk via `pod trunk push`.

> [!NOTE]  
> When triggered by a tag push, the workflow always runs with `dryRun: false`, meaning it will push to CocoaPods trunk.

> [!IMPORTANT] 
> To function properly, a secret named `COCOAPODS_TRUNK_TOKEN` must be added to the repository’s GitHub Actions secrets.

# Test
I’ve tested this action locally in my fork:
- [Here's the result of the lint](https://github.com/ArielDemarco/DataCompression/actions/runs/16808825069) which was triggered via the `workflow_dispatch` mechanism (aka. manually).
- [Here's the result of the push to trunk](https://github.com/ArielDemarco/DataCompression/actions/runs/16809059481/job/47609281633) (which obviously failed because I didn’t add a `COCOAPODS_TRUNK_TOKEN` in my fork, but it reached the push step, so it’s very likely that everything is set up correctly).
